### PR TITLE
Work around dangling reference error

### DIFF
--- a/include/uncertainty_planning_core/execution_policy.hpp
+++ b/include/uncertainty_planning_core/execution_policy.hpp
@@ -1079,9 +1079,11 @@ private:
           = planner_tree_.GetNodeImmutable(possible_match_state_idx);
       const UncertaintyPlanningState& possible_match_state
           = possible_match_tree_state.GetValueImmutable();
+      const auto possible_match_node_maybe_particles
+          = possible_match_state.GetParticlePositionsImmutable();
       const std::vector<Configuration, ConfigAlloc>&
           possible_match_node_particles
-              = possible_match_state.GetParticlePositionsImmutable().Value();
+              = possible_match_node_maybe_particles.Value();
       const bool is_cluster_member
           = particle_clustering_fn(
               possible_match_node_particles, current_config);
@@ -1153,9 +1155,11 @@ private:
             = planner_tree_.GetNodeImmutable(possible_match_state_idx);
         const UncertaintyPlanningState& possible_match_state
             = possible_match_tree_state.GetValueImmutable();
+        const auto possible_match_node_maybe_particles
+            = possible_match_state.GetParticlePositionsImmutable();
         const std::vector<Configuration, ConfigAlloc>&
             possible_match_node_particles
-                = possible_match_state.GetParticlePositionsImmutable().Value();
+                = possible_match_node_maybe_particles.Value();
         const bool is_cluster_member
             = particle_clustering_fn(
                 possible_match_node_particles, current_config);

--- a/include/uncertainty_planning_core/uncertainty_planning_core.hpp
+++ b/include/uncertainty_planning_core/uncertainty_planning_core.hpp
@@ -332,8 +332,9 @@ inline double UserGoalCheckWrapperFn(
 {
   if (state.HasParticles())
   {
+    const auto maybe_particles = state.GetParticlePositionsImmutable();
     const std::vector<Configuration, ConfigAlloc>& particle_positions
-        = state.GetParticlePositionsImmutable().Value();
+        = maybe_particles.Value();
     const size_t num_particles = state.GetNumParticles();
     if (num_particles > 0)
     {


### PR DESCRIPTION
Newer g++ on 24.04 incorrectly thinks references to state particles via `ReferencingMaybe<T>` are references to temporaries, and produces a dangling-references error. Instead of disabling the error for these cases, we work around it by keeping the query result in scope.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/uncertainty_planning_core/14)
<!-- Reviewable:end -->
